### PR TITLE
fixed description to match requires in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "evenement/evenement",
-    "description": "Événement is a very simple event dispatching library for PHP 5.3",
+    "description": "Événement is a very simple event dispatching library for PHP 5.4",
     "keywords": ["event-dispatcher"],
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Composer description says it's for 5.4 require is PHP 5.4 so just a simple correction for description
