### PR TITLE
Removed a call to call_user_func_array

### DIFF
--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -29,7 +29,7 @@ trait EventEmitterTrait
         $onceListener = function () use (&$onceListener, $event, $listener) {
             $this->removeListener($event, $onceListener);
 
-            call_user_func_array($listener, func_get_args());
+            $listener($event, $listener);
         };
 
         $this->on($event, $onceListener);


### PR DESCRIPTION
`call_user_func_array` can be not performant, so changed to a direct call instead
