### PR TITLE
Indexed event listeners

### DIFF
--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -21,7 +21,8 @@ trait EventEmitterTrait
             $this->listeners[$event] = [];
         }
 
-        $this->listeners[$event][] = $listener;
+        $index = static::buildIndex($listener);
+        $this->listeners[$event][$index] = $listener;
     }
 
     public function once($event, callable $listener)
@@ -38,7 +39,8 @@ trait EventEmitterTrait
     public function removeListener($event, callable $listener)
     {
         if (isset($this->listeners[$event])) {
-            if (false !== $index = array_search($listener, $this->listeners[$event], true)) {
+            $index = static::buildIndex($listener);
+            if (isset($this->listeners[$event][$index])) {
                 unset($this->listeners[$event][$index]);
             }
         }
@@ -63,5 +65,22 @@ trait EventEmitterTrait
         foreach ($this->listeners($event) as $listener) {
             call_user_func_array($listener, $arguments);
         }
+    }
+
+    protected static function buildIndex($listener)
+    {
+        if (is_string($listener)) {
+            return $listener;
+        }
+
+        if (is_array($listener)) {
+            $key = '';
+            foreach ($listener as $part) {
+                $key .= self::buildIndex($part);
+            }
+            return $key;
+        }
+
+        return spl_object_hash($listener);
     }
 }


### PR DESCRIPTION
I pretty much made this PR to start a discussion.

In this PR:
- Indexed listeners.
- Listeners cannot be added twice. #7 is related.
- Performance of removeListener is significantly improved with a lot of listeners O(N) to Olog(N).

Bug in this PR:
- With once a duplicate listener can be added. (This is fixable).

Do you think this is a common use case and are you willing to support it? If so, we might want to make a different trait, so you can choose whatever case suits your project best.
