### PR TITLE
Implemented a static event emitter

### DIFF
--- a/src/Evenement/StaticEventEmitterTrait.php
+++ b/src/Evenement/StaticEventEmitterTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Evenement.
+ *
+ * (c) Igor Wiedler <igor@wiedler.ch>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Evenement;
+
+trait StaticEventEmitterTrait
+{
+    private static $emitter;
+
+    public static function emitter() {
+        if (!isset(self::$emitter)) {
+            self::$emitter = new EventEmitter();
+        }
+        return self::$emitter;
+    }
+
+    public static function __callStatic($name, $args)
+    {
+        $emitter = self::emitter();
+
+        if (method_exists($emitter, $name)) {
+            return call_user_func_array([$emitter, $name], $args);
+        }
+
+        // Produce a fatal error if method does not exist
+        $class = static::class;
+        trigger_error("Call to undefined method $class::$name()", E_USER_ERROR);
+    }
+}

--- a/tests/Evenement/Tests/StaticEventEmitter.php
+++ b/tests/Evenement/Tests/StaticEventEmitter.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Evenement.
+ *
+ * (c) Igor Wiedler <igor@wiedler.ch>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Evenement\Tests;
+
+use Evenement\StaticEventEmitterTrait;
+
+class StaticEventEmitter
+{
+    use StaticEventEmitterTrait;
+}

--- a/tests/Evenement/Tests/StaticEventEmitterTest.php
+++ b/tests/Evenement/Tests/StaticEventEmitterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Evenement.
+ *
+ * (c) Igor Wiedler <igor@wiedler.ch>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Evenement\Tests;
+
+use Evenement\EventEmitter;
+
+class StaticEventEmitterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEmitter()
+    {
+        $emitter = StaticEventEmitter::emitter();
+        $this->assertInstanceOf('\\Evenement\\EventEmitter', $emitter);
+    }
+
+    public function testAdd()
+    {
+        StaticEventEmitter::on('foo', function () {});
+    }
+
+    public function testEmit()
+    {
+        $listenerCalled = false;
+
+        StaticEventEmitter::on('foo', function () use (&$listenerCalled) {
+            $listenerCalled = true;
+        });
+
+        $this->assertFalse($listenerCalled);
+        StaticEventEmitter::emit('foo');
+        $this->assertTrue($listenerCalled);
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     * @expectedExceptionMessage Call to undefined method Evenement\Tests\StaticEventEmitter::foo()
+     */
+    public function testMethodDoesNotExist()
+    {
+        StaticEventEmitter::foo();
+    }
+}


### PR DESCRIPTION
I have a use case where i need static calls to the event emitter.

This PR provides a trait which provides all the EventEmitter methods statically.

The solution uses __callStatic to forward calls to an instance of EventEmitter. This prevents any code duplication, since the StaticEventEmitterTrait does not need to be changed when EventEmitter is changed. There is a performance hit, but it's not that bad. 

I did some performance testing (https://gist.github.com/ihabunek/8803125). And for 100 listeners, and 100k events, the results are:

```
Dynamic adding: 0
Dynamic emitting: 4.2352
--
Static adding: 0.001
Static emitting: 4.3292
```

Also, the performance hit can be mitigated by using:

```
MyEmitter::emitter()->on(...);
```

instead of the shorter version which invokes __callStatic:

```
MyEmitter::on(...);
```
