### PR TITLE
Emit uses variadic arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - hhvm
- 
+
 matrix:
     allow_failures:
         - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.6.0"
     },
     "autoload": {
         "psr-0": {
@@ -21,5 +21,8 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.6"
     }
 }

--- a/doc/01-api.md
+++ b/doc/01-api.md
@@ -40,19 +40,19 @@ Example:
         $conn->send($data);
     });
 
-## emit($event, array $arguments = [])
+## emit($event, ...$arguments)
 
 Emit an event, which will call all listeners.
 
 Example:
 
-    $conn->emit('data', array($data));
+    $conn->emit('data', $data);
 
-The second argument to emit is an array of listener arguments. This is how you
+Emit is variadic and each argument will be gathered into an array of listener arguments. This is how you
 specify more args:
 
     $result = $a + $b;
-    $emitter->emit('numbers_added', array($result, $a, $b));
+    $emitter->emit('numbers_added', $result, $a, $b);
 
 ## listeners($event)
 

--- a/doc/02-plugin-system.md
+++ b/doc/02-plugin-system.md
@@ -83,7 +83,7 @@ In the code that creates the post, I'll insert the `post.create` event:
     $post = createPostFromRequest($_POST);
 
     $event = new PostEvent($post);
-    $emitter->emit('post.create', array($event));
+    $emitter->emit('post.create', $event);
     $post = $event->post;
 
     $db->save('post', $post);
@@ -98,7 +98,7 @@ The same thing for the `post.render` event:
         $emitter = $this->emitter;
 
         $event = new PostEvent($post);
-        $emitter->emit('post.render', array($event));
+        $emitter->emit('post.render', $event);
         $post = $event->post;
 
         return $post['body'];

--- a/src/Evenement/EventEmitterInterface.php
+++ b/src/Evenement/EventEmitterInterface.php
@@ -18,5 +18,5 @@ interface EventEmitterInterface
     public function removeListener($event, callable $listener);
     public function removeAllListeners($event = null);
     public function listeners($event);
-    public function emit($event, array $arguments = []);
+    public function emit($event, ...$arguments);
 }

--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -29,7 +29,7 @@ trait EventEmitterTrait
         $onceListener = function () use (&$onceListener, $event, $listener) {
             $this->removeListener($event, $onceListener);
 
-            call_user_func_array($listener, func_get_args());
+            $listener(...func_get_args());
         };
 
         $this->on($event, $onceListener);
@@ -59,10 +59,10 @@ trait EventEmitterTrait
         return isset($this->listeners[$event]) ? $this->listeners[$event] : [];
     }
 
-    public function emit($event, array $arguments = [])
+    public function emit($event, ...$arguments)
     {
         foreach ($this->listeners($event) as $listener) {
-            call_user_func_array($listener, $arguments);
+            $listener(...$arguments);
         }
     }
 }

--- a/tests/Evenement/Tests/EventEmitterTest.php
+++ b/tests/Evenement/Tests/EventEmitterTest.php
@@ -74,7 +74,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
             $capturedArgs = array($a, $b);
         });
 
-        $this->emitter->emit('foo', array('a', 'b'));
+        $this->emitter->emit('foo', 'a', 'b');
 
         $this->assertSame(array('a', 'b'), $capturedArgs);
     }
@@ -105,7 +105,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
         });
 
         $this->assertSame(false, $listenerCalled);
-        $this->emitter->emit('foo', ['bar']);
+        $this->emitter->emit('foo', 'bar');
         $this->assertSame(true, $listenerCalled);
     }
 
@@ -123,7 +123,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
         });
 
         $this->assertSame(false, $listenerCalled);
-        $this->emitter->emit('foo', ['bar', 'baz']);
+        $this->emitter->emit('foo', 'bar', 'baz');
         $this->assertSame(true, $listenerCalled);
     }
 


### PR DESCRIPTION
Now that PHP 5.6 supports variadic functions, Événement can be even more in step with the EventEmitter API from node.js.

I am guessing this would require a new major release as it changes how one uses Événement.