### PR TITLE
Free unused array indexes

### DIFF
--- a/src/Evenement/EventEmitterInterface.php
+++ b/src/Evenement/EventEmitterInterface.php
@@ -17,6 +17,6 @@ interface EventEmitterInterface
     public function once($event, callable $listener);
     public function removeListener($event, callable $listener);
     public function removeAllListeners($event = null);
-    public function listeners($event);
+    public function listeners($event = null);
     public function emit($event, array $arguments = []);
 }

--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -41,6 +41,9 @@ trait EventEmitterTrait
             $index = array_search($listener, $this->listeners[$event], true);
             if (false !== $index) {
                 unset($this->listeners[$event][$index]);
+                if (count($this->listeners[$event]) === 0) {
+                    unset($this->listeners[$event]);
+                }
             }
         }
     }

--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -57,9 +57,13 @@ trait EventEmitterTrait
         }
     }
 
-    public function listeners($event)
+    public function listeners($event = null)
     {
-        return isset($this->listeners[$event]) ? $this->listeners[$event] : [];
+        if ($event !== null) {
+            return isset($this->listeners[$event]) ? $this->listeners[$event] : [];
+        }
+
+        return $this->listeners;
     }
 
     public function emit($event, array $arguments = [])


### PR DESCRIPTION
Unset the event if there are no more indexed listeners to avoid memory issues.  Basically a leak fix.
