### PR TITLE
Fix a test to catch TypeError and Exception.

### DIFF
--- a/tests/Evenement/Tests/EventEmitterTest.php
+++ b/tests/Evenement/Tests/EventEmitterTest.php
@@ -44,6 +44,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
             $this->emitter->on('foo', 'not a callable');
             $this->fail();
         } catch (\Exception $e) {
+        } catch (\TypeError $e) {
         }
     }
 


### PR DESCRIPTION
In PHP 7, TypeError is no longer an Exception but is an Error
instead. This commit adjusts a test case to catch TypeError instead
of Exception.