### PR TITLE
Allow to pass single argument directly, instead of always encapsulating it into an array

### DIFF
--- a/src/Evenement/EventEmitterInterface.php
+++ b/src/Evenement/EventEmitterInterface.php
@@ -18,5 +18,5 @@ interface EventEmitterInterface
     public function removeListener($event, callable $listener);
     public function removeAllListeners($event = null);
     public function listeners($event);
-    public function emit($event, array $arguments = []);
+    public function emit($event, $arguments = []);
 }

--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -59,10 +59,10 @@ trait EventEmitterTrait
         return isset($this->listeners[$event]) ? $this->listeners[$event] : [];
     }
 
-    public function emit($event, array $arguments = [])
+    public function emit($event, $arguments = [])
     {
         foreach ($this->listeners($event) as $listener) {
-            call_user_func_array($listener, $arguments);
+            call_user_func_array($listener, (array) $arguments);
         }
     }
 }

--- a/tests/Evenement/Tests/EventEmitterTest.php
+++ b/tests/Evenement/Tests/EventEmitterTest.php
@@ -15,6 +15,7 @@ use Evenement\EventEmitter;
 
 class EventEmitterTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var  EventEmitter */
     private $emitter;
 
     public function setUp()
@@ -43,7 +44,7 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
         try {
             $this->emitter->on('foo', 'not a callable');
             $this->fail();
-        } catch (\Exception $e) {
+        } catch (\Error $e) {
         }
     }
 
@@ -96,17 +97,19 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
     {
         $test = $this;
 
-        $listenerCalled = false;
+        $listenerCalled = 0;
 
         $this->emitter->on('foo', function ($value) use (&$listenerCalled, $test) {
-            $listenerCalled = true;
+            $listenerCalled++;
 
             $test->assertSame('bar', $value);
         });
 
-        $this->assertSame(false, $listenerCalled);
+        $this->assertSame(0, $listenerCalled);
         $this->emitter->emit('foo', ['bar']);
-        $this->assertSame(true, $listenerCalled);
+        $this->assertSame(1, $listenerCalled);
+        $this->emitter->emit('foo', 'bar');
+        $this->assertSame(2, $listenerCalled);
     }
 
     public function testEmitWithTwoArguments()


### PR DESCRIPTION
Why force user to encapsulate arguments into an array? Let's allow him to pass it directly if he needs single argument