### PR TITLE
Free unused array indexes

### DIFF
--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -41,6 +41,9 @@ trait EventEmitterTrait
             $index = array_search($listener, $this->listeners[$event], true);
             if (false !== $index) {
                 unset($this->listeners[$event][$index]);
+                if (count($this->listeners[$event]) === 0) {
+                    unset($this->listeners[$event]);
+                }
             }
         }
     }


### PR DESCRIPTION
Cherry picked the memory leak fix from #32 by @wormling without pulling in the BC break.