### PR TITLE
Keep separate list for once listeners

### DIFF
--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -78,7 +78,10 @@ trait EventEmitterTrait
 
     public function listeners($event)
     {
-        return (isset($this->listeners[$event]) ? $this->listeners[$event] : []) + (isset($this->onceListeners[$event]) ? $this->onceListeners[$event] : []);
+        return array_merge(
+            isset($this->listeners[$event]) ? $this->listeners[$event] : [],
+            isset($this->onceListeners[$event]) ? $this->onceListeners[$event] : []
+        );
     }
 
     public function emit($event, array $arguments = [])

--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -14,6 +14,7 @@ namespace Evenement;
 trait EventEmitterTrait
 {
     protected $listeners = [];
+    protected $onceListeners = [];
 
     public function on($event, callable $listener)
     {
@@ -28,13 +29,13 @@ trait EventEmitterTrait
 
     public function once($event, callable $listener)
     {
-        $onceListener = function (...$args) use (&$onceListener, $event, $listener) {
-            $this->removeListener($event, $onceListener);
+        if (!isset($this->onceListeners[$event])) {
+            $this->onceListeners[$event] = [];
+        }
 
-            $listener(...$args);
-        };
+        $this->onceListeners[$event][] = $listener;
 
-        $this->on($event, $onceListener);
+        return $this;
     }
 
     public function removeListener($event, callable $listener)
@@ -48,6 +49,16 @@ trait EventEmitterTrait
                 }
             }
         }
+
+        if (isset($this->onceListeners[$event])) {
+            $index = \array_search($listener, $this->onceListeners[$event], true);
+            if (false !== $index) {
+                unset($this->onceListeners[$event][$index]);
+                if (\count($this->onceListeners[$event]) === 0) {
+                    unset($this->onceListeners[$event]);
+                }
+            }
+        }
     }
 
     public function removeAllListeners($event = null)
@@ -57,17 +68,34 @@ trait EventEmitterTrait
         } else {
             $this->listeners = [];
         }
+
+        if ($event !== null) {
+            unset($this->onceListeners[$event]);
+        } else {
+            $this->onceListeners = [];
+        }
     }
 
     public function listeners($event)
     {
-        return isset($this->listeners[$event]) ? $this->listeners[$event] : [];
+        return (isset($this->listeners[$event]) ? $this->listeners[$event] : []) + (isset($this->onceListeners[$event]) ? $this->onceListeners[$event] : []);
     }
 
     public function emit($event, array $arguments = [])
     {
-        foreach ($this->listeners($event) as $listener) {
-            $listener(...$arguments);
+        if (isset($this->listeners[$event])) {
+            foreach ($this->listeners[$event] as $listener) {
+                $listener(...$arguments);
+            }
+        }
+
+        if (isset($this->onceListeners[$event])) {
+            $listeners = $this->onceListeners[$event];
+            foreach ($listeners as $listener) {
+                $listener(...$arguments);
+            }
+
+            $this->onceListeners[$event] = [];
         }
     }
 }

--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -93,12 +93,15 @@ trait EventEmitterTrait
         }
 
         if (isset($this->onceListeners[$event])) {
-            $listeners = $this->onceListeners[$event];
-            foreach ($listeners as $listener) {
-                $listener(...$arguments);
+            $keys = array_keys($this->onceListeners[$event]);
+            foreach ($keys as $key) {
+                ($this->onceListeners[$event][$key])(...$arguments);
+                unset($this->onceListeners[$event][$key]);
             }
 
-            $this->onceListeners[$event] = [];
+            if (count($this->onceListeners[$event]) === 0) {
+                unset($this->onceListeners[$event]);
+            }
         }
     }
 }

--- a/tests/Evenement/Tests/EventEmitterTest.php
+++ b/tests/Evenement/Tests/EventEmitterTest.php
@@ -288,4 +288,46 @@ class EventEmitterTest extends TestCase
 
         unset($GLOBALS['evenement-evenement-test-data']);
     }
+
+    public function testListeners()
+    {
+        $onA = function () {};
+        $onB = function () {};
+        $onC = function () {};
+        $onceA = function () {};
+        $onceB = function () {};
+        $onceC = function () {};
+
+        self::assertCount(0, $this->emitter->listeners('event'));
+        $this->emitter->on('event', $onA);
+        self::assertCount(1, $this->emitter->listeners('event'));
+        self::assertSame([$onA], $this->emitter->listeners('event'));
+        $this->emitter->once('event', $onceA);
+        self::assertCount(2, $this->emitter->listeners('event'));
+        self::assertSame([$onA, $onceA], $this->emitter->listeners('event'));
+        $this->emitter->once('event', $onceB);
+        self::assertCount(3, $this->emitter->listeners('event'));
+        self::assertSame([$onA, $onceA, $onceB], $this->emitter->listeners('event'));
+        $this->emitter->on('event', $onB);
+        self::assertCount(4, $this->emitter->listeners('event'));
+        self::assertSame([$onA, $onB, $onceA, $onceB], $this->emitter->listeners('event'));
+        $this->emitter->removeListener('event', $onceA);
+        self::assertCount(3, $this->emitter->listeners('event'));
+        self::assertSame([$onA, $onB, $onceB], $this->emitter->listeners('event'));
+        $this->emitter->once('event', $onceC);
+        self::assertCount(4, $this->emitter->listeners('event'));
+        self::assertSame([$onA, $onB, $onceB, $onceC], $this->emitter->listeners('event'));
+        $this->emitter->on('event', $onC);
+        self::assertCount(5, $this->emitter->listeners('event'));
+        self::assertSame([$onA, $onB, $onC, $onceB, $onceC], $this->emitter->listeners('event'));
+        $this->emitter->once('event', $onceA);
+        self::assertCount(6, $this->emitter->listeners('event'));
+        self::assertSame([$onA, $onB, $onC, $onceB, $onceC, $onceA], $this->emitter->listeners('event'));
+        $this->emitter->removeListener('event', $onB);
+        self::assertCount(5, $this->emitter->listeners('event'));
+        self::assertSame([$onA, $onC, $onceB, $onceC, $onceA], $this->emitter->listeners('event'));
+        $this->emitter->emit('event');
+        self::assertCount(2, $this->emitter->listeners('event'));
+        self::assertSame([$onA, $onC], $this->emitter->listeners('event'));
+    }
 }

--- a/tests/Evenement/Tests/EventEmitterTest.php
+++ b/tests/Evenement/Tests/EventEmitterTest.php
@@ -330,4 +330,29 @@ class EventEmitterTest extends TestCase
         self::assertCount(2, $this->emitter->listeners('event'));
         self::assertSame([$onA, $onC], $this->emitter->listeners('event'));
     }
+
+    public function testOnceCallIsNotRemovedWhenWorkingOverOnceListeners()
+    {
+        $aCalled = false;
+        $aCallable = function () use (&$aCalled) {
+            $aCalled = true;
+        };
+        $bCalled = false;
+        $bCallable = function () use (&$bCalled, $aCallable) {
+            $bCalled = true;
+            $this->emitter->once('event', $aCallable);
+        };
+        $this->emitter->once('event', $bCallable);
+
+        self::assertFalse($aCalled);
+        self::assertFalse($bCalled);
+        $this->emitter->emit('event');
+
+        self::assertFalse($aCalled);
+        self::assertTrue($bCalled);
+        $this->emitter->emit('event');
+
+        self::assertTrue($aCalled);
+        self::assertTrue($bCalled);
+    }
 }


### PR DESCRIPTION
Supersedes / Closes #18 

This PR gives the once listeners a nice performance boost and adds the ability to remove them.