### PR TITLE
Resolved regression introduced in once listeners in v3.0.0

### DIFF
--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -125,14 +125,10 @@ trait EventEmitterTrait
         }
 
         if (isset($this->onceListeners[$event])) {
-            $keys = \array_keys($this->onceListeners[$event]);
-            foreach ($keys as $key) {
-                ($this->onceListeners[$event][$key])(...$arguments);
-                unset($this->onceListeners[$event][$key]);
-            }
-
-            if (\count($this->onceListeners[$event]) === 0) {
-                unset($this->onceListeners[$event]);
+            $listeners = $this->onceListeners[$event];
+            unset($this->onceListeners[$event]);
+            foreach ($listeners as $listener) {
+                $listener(...$arguments);
             }
         }
     }

--- a/tests/Evenement/Tests/EventEmitterTest.php
+++ b/tests/Evenement/Tests/EventEmitterTest.php
@@ -417,4 +417,22 @@ class EventEmitterTest extends TestCase
             $this->emitter->listeners()
         );
     }
+
+    public function testOnceNestedCallRegression()
+    {
+        $first = 0;
+        $second = 0;
+
+        $this->emitter->once('event', function () use (&$first, &$second) {
+            $first++;
+            $this->emitter->once('event', function () use (&$second) {
+                $second++;
+            });
+            $this->emitter->emit('event');
+        });
+        $this->emitter->emit('event');
+
+        self::assertSame(1, $first);
+        self::assertSame(1, $second);
+    }
 }


### PR DESCRIPTION
Copy and clear the once listener list before calling all listeners, this way when you emit that event from within a listener you don't get stick in an infinite loop