### PR TITLE
Added forward feature

### DIFF
--- a/src/Evenement/EventEmitterInterface.php
+++ b/src/Evenement/EventEmitterInterface.php
@@ -19,4 +19,5 @@ interface EventEmitterInterface
     public function removeAllListeners($event = null);
     public function listeners($event = null);
     public function emit($event, array $arguments = []);
+    public function forward(EventEmitterInterface $emitter);
 }

--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -17,6 +17,7 @@ trait EventEmitterTrait
 {
     protected $listeners = [];
     protected $onceListeners = [];
+    protected $children = [];
 
     public function on($event, callable $listener)
     {
@@ -131,5 +132,15 @@ trait EventEmitterTrait
                 $listener(...$arguments);
             }
         }
+
+        foreach($this->children as $child)
+        {
+            $child->emit($event, $arguments);
+        }
+    }
+
+    public function forward(EventEmitterInterface $emitter)
+    {
+        $this->children[] = $emitter;
     }
 }

--- a/tests/Evenement/Tests/EventEmitterTest.php
+++ b/tests/Evenement/Tests/EventEmitterTest.php
@@ -435,4 +435,14 @@ class EventEmitterTest extends TestCase
         self::assertSame(1, $first);
         self::assertSame(1, $second);
     }
+
+    public function testInheritance()
+    {
+        $child = new EventEmitter();
+        $this->emitter->forward($child);
+        $child->on('hello', function ($data) {
+            self::assertSame('hello from parent', $data);
+        });
+        $this->emitter->emit('hello', ['hello from parent']);
+    }
 }


### PR DESCRIPTION
# Event Forwarding

This PR would permit forwarding emitted events between a parent and its children without the need of registering listeners, to the parent, and re-emitting it to the child's listeners. Simply, by passing an object implementing EventEmitterInterface to `EventEmitter::forward`. Moreover when `EventEmitter::emit` is called, it will iterate over the children's array and call their emit method with identical arguments.