### PR TITLE
Moved once::before into it's own method

### DIFF
--- a/src/Evenement/EventEmitterInterface.php
+++ b/src/Evenement/EventEmitterInterface.php
@@ -14,7 +14,8 @@ namespace Evenement;
 interface EventEmitterInterface
 {
     public function on($event, callable $listener);
-    public function once($event, callable $listener, bool $before = false);
+    public function onceBefore($event, callable $listener);
+    public function once($event, callable $listener);
     public function removeListener($event, callable $listener);
     public function removeAllListeners($event = null);
     public function listeners($event = null);

--- a/src/Evenement/EventEmitterTrait.php
+++ b/src/Evenement/EventEmitterTrait.php
@@ -35,7 +35,22 @@ trait EventEmitterTrait
         return $this;
     }
 
-    public function once($event, callable $listener, bool $before = false)
+    public function onceBefore($event, callable $listener)
+    {
+        if ($event === null) {
+            throw new InvalidArgumentException('event name must not be null');
+        }
+
+        if (!isset($this->beforeOnceListeners[$event])) {
+            $this->beforeOnceListeners[$event] = [];
+        }
+
+        $this->beforeOnceListeners[$event][] = $listener;
+
+        return $this;
+    }
+
+    public function once($event, callable $listener)
     {
         if ($event === null) {
             throw new InvalidArgumentException('event name must not be null');
@@ -45,12 +60,7 @@ trait EventEmitterTrait
             $this->onceListeners[$event] = [];
         }
 
-
-        if ($before) {
-            $this->beforeOnceListeners[$event][] = $listener;
-        } else {
-            $this->onceListeners[$event][] = $listener;
-        }
+        $this->onceListeners[$event][] = $listener;
 
         return $this;
     }

--- a/tests/Evenement/Tests/EventEmitterTest.php
+++ b/tests/Evenement/Tests/EventEmitterTest.php
@@ -85,14 +85,14 @@ class EventEmitterTest extends TestCase
         $this->assertSame(array('a', 'b'), $capturedArgs);
     }
 
-    public function testOnceBefore()
+    public function testOncePre()
     {
         $listenerCalled = [];
 
-        $this->emitter->once('foo', function () use (&$listenerCalled) {
+        $this->emitter->onceBefore('foo', function () use (&$listenerCalled) {
             $this->assertSame([], $listenerCalled);
             $listenerCalled[] = 1;
-        }, true);
+        });
 
         $this->emitter->on('foo', function () use (&$listenerCalled) {
             $this->assertSame([1], $listenerCalled);


### PR DESCRIPTION
Reason is that the interface change breaks any custom implementations
of it and is therefor a BC break that can only happen in 4.0.

https://3v4l.org/Npc3u

Refs #59