### PR TITLE
Return to the concise and simple api

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $emitter->on('user.created', function (User $user) use ($logger) {
 
 ```php
 <?php
-$emitter->off('user.created', function (User $user) use ($logger) {
+$emitter->removeListener('user.created', function (User $user) use ($logger) {
     $logger->log(sprintf("User '%s' was created.", $user->getLogin()));
 });
 ```

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3"
+        "php": ">=7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9 || ^6"

--- a/doc/01-api.md
+++ b/doc/01-api.md
@@ -89,27 +89,3 @@ Remove a specific listener for a specific event.
 Remove all listeners for a specific event or all listeners all together. This
 is useful for long-running processes, where you want to remove listeners in
 order to allow them to get garbage collected.
-
-
-## off($event, callable $listener = null)
-
-Executes removeAllListeners($event = null) if $listener is null, otherwise 
-execute removeListener($event, callable $listener)
-
-## eventNames()
-
-Allows you to get all names to added event.
-
-Example:
-
-```php
-$emitter->on('event1', function () {});
-$emitter->on('event2', function () {});
-$emitter->once('event3', function () {});
-
-$result = $emitter->eventNames() //$result  == ['event1', 'event2', 'event3'] 
-```
-
-## forward(EventEmitterInterface $emitter)
-
-todo

--- a/src/EventEmitterInterface.php
+++ b/src/EventEmitterInterface.php
@@ -14,11 +14,9 @@ namespace Evenement;
 interface EventEmitterInterface
 {
     public function on($event, callable $listener);
-    public function onceBefore($event, callable $listener);
     public function once($event, callable $listener);
     public function removeListener($event, callable $listener);
     public function removeAllListeners($event = null);
     public function listeners($event = null);
     public function emit($event, array $arguments = []);
-    public function forward(EventEmitterInterface $emitter);
 }

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -22,7 +22,10 @@ class EventEmitterTest extends TestCase
      */
     private $emitter;
 
-    public function setUp(): void
+    /**
+     * @before
+     */
+    public function setUpEmitter()
     {
         $this->emitter = new EventEmitter();
     }
@@ -89,32 +92,6 @@ class EventEmitterTest extends TestCase
         $this->emitter->emit('foo', array('a', 'b'));
 
         $this->assertSame(array('a', 'b'), $capturedArgs);
-    }
-
-    public function testOncePre()
-    {
-        $listenerCalled = [];
-
-        $this->emitter->onceBefore('foo', function () use (&$listenerCalled) {
-            $this->assertSame([], $listenerCalled);
-            $listenerCalled[] = 1;
-        });
-
-        $this->emitter->on('foo', function () use (&$listenerCalled) {
-            $this->assertSame([1], $listenerCalled);
-            $listenerCalled[] = 2;
-        });
-
-        $this->emitter->once('foo', function () use (&$listenerCalled) {
-            $this->assertSame([1, 2], $listenerCalled);
-            $listenerCalled[] = 3;
-        });
-
-        $this->assertSame([], $listenerCalled);
-
-        $this->emitter->emit('foo');
-
-        $this->assertSame([1, 2, 3], $listenerCalled);
     }
 
     public function testEmitWithoutArguments()
@@ -472,50 +449,6 @@ class EventEmitterTest extends TestCase
         self::assertSame(1, $second);
     }
 
-    public function testInheritance()
-    {
-        $child = new EventEmitter();
-        $this->emitter->forward($child);
-        $child->on('hello', function ($data) {
-            self::assertSame('hello from parent', $data);
-        });
-        $this->emitter->emit('hello', ['hello from parent']);
-    }
-
-    public function testOff()
-    {
-        self::assertSame([], $this->emitter->listeners());
-
-        $listener = function () {
-        };
-        $this->emitter->on('event', $listener);
-        $this->emitter->on('tneve', $listener);
-        self::assertSame(
-            [
-                'event' => [
-                    $listener,
-                ],
-                'tneve' => [
-                    $listener,
-                ],
-            ],
-            $this->emitter->listeners()
-        );
-
-        $this->emitter->off('tneve', $listener);
-        self::assertSame(
-            [
-                'event' => [
-                    $listener,
-                ],
-            ],
-            $this->emitter->listeners()
-        );
-
-        $this->emitter->off('event');
-        self::assertSame([], $this->emitter->listeners());
-    }
-
     public function testNestedOn()
     {
         $emitter = $this->emitter;
@@ -543,16 +476,5 @@ class EventEmitterTest extends TestCase
         $this->assertEquals(2, $first);
         $this->assertEquals(1, $second);
         $this->assertEquals(1, $third);
-    }
-
-    public function testEventNames()
-    {
-        $emitter = $this->emitter;
-
-        $emitter->on('event1', function () {});
-        $emitter->on('event2', function () {});
-        $emitter->once('event3', function () {});
-
-        $this->assertEquals(['event1', 'event2', 'event3'], $emitter->eventNames());
     }
 }


### PR DESCRIPTION
Over time changes and additions were introduced to this package. By accepting those changes I lost "concise and simple" out of sight. This PR reverts the changes conflicting with that. While some of those might make sense to have, they broke backward compatibility.

It's been 3 - 6 years some of those changes were introduced and I haven't released a new version since then. After accepting them into this package (almost) no one reached out about releasing a new version. That suggest those changes aren't used, or they are targeting a dev branch. If you are affected by this revert PR somehow, the composer documentation contains [how to target a commit sha](https://getcomposer.org/doc/04-schema.md#package-links).

Last but not least, reverting this yields a 5% - 10% performance improvement.