### PR TITLE
chore(docs): update readme to fix the 'badge poser' images

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ It is very strongly inspired by the [EventEmitter](https://nodejs.org/api/events
 [node.js](http://nodejs.org).
 
 ![Continuous Integration](https://github.com/igorw/evenement/workflows/CI/badge.svg)
-[![Latest Stable Version](https://poser.pugx.org/evenement/evenement/v/stable.png)](https://packagist.org/packages/evenement/evenement)
-[![Total Downloads](https://poser.pugx.org/evenement/evenement/downloads.png)](https://packagist.org/packages/evenement/evenement/stats)
-[![License](https://poser.pugx.org/evenement/evenement/license.png)](https://packagist.org/packages/evenement/evenement)
+[![Latest Stable Version](https://poser.pugx.org/evenement/evenement/v)](https://packagist.org/packages/evenement/evenement)
+[![Total Downloads](https://poser.pugx.org/evenement/evenement/downloads)](https://packagist.org/packages/evenement/evenement)
+[![License](http://poser.pugx.org/evenement/evenement/license)](https://packagist.org/packages/evenement/evenement)
 
 ## Fetch
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is very strongly inspired by the [EventEmitter](https://nodejs.org/api/events
 ![Continuous Integration](https://github.com/igorw/evenement/workflows/CI/badge.svg)
 [![Latest Stable Version](https://poser.pugx.org/evenement/evenement/v)](https://packagist.org/packages/evenement/evenement)
 [![Total Downloads](https://poser.pugx.org/evenement/evenement/downloads)](https://packagist.org/packages/evenement/evenement)
-[![License](http://poser.pugx.org/evenement/evenement/license)](https://packagist.org/packages/evenement/evenement)
+[![License](https://poser.pugx.org/evenement/evenement/license)](https://packagist.org/packages/evenement/evenement)
 
 ## Fetch
 


### PR DESCRIPTION
This PR corrects the `badge poser` image URL's used for `Latest Stable Version`, `Total Downloads`, and `License`; it seems the format was slightly changed.

This should allow the images to display. The previous URL's apparently weren't able to be proxied by GitHub.